### PR TITLE
Replace JSON::Any with JSON

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -32,7 +32,6 @@ MIME::Base64 = 0
 [Prereqs]
 Array::Iterator = 0
 HTTP::Message = 0
-JSON::Any = 0
 JSON = 0
 LWP::Protocol::https = 0
 LWP::UserAgent = 0

--- a/lib/Pithub/Base.pm
+++ b/lib/Pithub/Base.pm
@@ -6,7 +6,7 @@ use Moo;
 use Carp qw(croak);
 use HTTP::Headers;
 use HTTP::Request;
-use JSON::Any;
+use JSON;
 use LWP::UserAgent;
 use Pithub::Result;
 use URI;
@@ -526,7 +526,7 @@ API call.
 =item *
 
 B<data>: optional data reference, usually a reference to an array
-or hash. It must be possible to serialize this using L<JSON::Any>.
+or hash. It must be possible to serialize this using L<JSON>.
 This will be the HTTP request body.
 
 =item *
@@ -685,7 +685,7 @@ sub has_token {
 
 sub _build__json {
     my ($self) = @_;
-    return JSON::Any->new;
+    return JSON->new;
 }
 
 sub _build_ua {

--- a/lib/Pithub/Result.pm
+++ b/lib/Pithub/Result.pm
@@ -4,7 +4,7 @@ package Pithub::Result;
 
 use Moo;
 use Array::Iterator;
-use JSON::Any;
+use JSON;
 use URI;
 
 =head1 DESCRIPTION
@@ -160,7 +160,7 @@ has '_iterator' => (
 has '_json' => (
     builder => '_build__json',
     is      => 'ro',
-    isa     => sub { die 'must be a JSON::Any, but is ' . ref $_[0] unless ref $_[0] eq 'JSON::Any' },
+    isa     => sub { die 'must be a JSON, but is ' . ref $_[0] unless ref $_[0] eq 'JSON' },
     lazy    => 1,
 );
 
@@ -427,7 +427,7 @@ sub _build_prev_page_uri {
 
 sub _build__json {
     my ($self) = @_;
-    return JSON::Any->new;
+    return JSON->new;
 }
 
 sub _get_link_header {

--- a/t/basic.t
+++ b/t/basic.t
@@ -1,6 +1,6 @@
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use JSON::Any;
+use JSON;
 use Pithub::Test;
 use Pithub::Test::UA;
 use Test::Most;
@@ -352,7 +352,7 @@ sub validate_tree {
 }
 
 {
-    my $json = JSON::Any->new;
+    my $json = JSON->new;
     my $p    = Pithub::Test->create('Pithub');
     $p->token('123');
     my $request = $p->request( method => 'POST', path => '/foo', data => { some => 'data' } )->request;

--- a/t/gists.t
+++ b/t/gists.t
@@ -1,6 +1,6 @@
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use JSON::Any;
+use JSON;
 use Pithub::Test;
 use Test::Most;
 
@@ -11,7 +11,7 @@ BEGIN {
 
 # Pithub::Gists->create
 {
-    my $json = JSON::Any->new;
+    my $json = JSON->new;
     my $obj  = Pithub::Test->create('Pithub::Gists');
 
     isa_ok $obj, 'Pithub::Gists';
@@ -204,7 +204,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json   = JSON::Any->new;
+        my $json   = JSON->new;
         my $result = $obj->update(
             gist_id => 123,
             data    => {
@@ -236,7 +236,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json = JSON::Any->new;
+        my $json = JSON->new;
         my $result = $obj->create( gist_id => 123, data => { body => 'some comment' } );
         is $result->request->method, 'POST', 'HTTP method';
         is $result->request->uri->path, '/gists/123/comments', 'HTTP path';
@@ -313,7 +313,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json = JSON::Any->new;
+        my $json = JSON->new;
         my $result = $obj->update( comment_id => 123, data => { body => 'some comment' } );
         is $result->request->method, 'PATCH', 'HTTP method';
         is $result->request->uri->path, '/gists/comments/123', 'HTTP path';

--- a/t/git_data.t
+++ b/t/git_data.t
@@ -1,6 +1,6 @@
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use JSON::Any;
+use JSON;
 use Pithub::Test;
 use Test::Most;
 
@@ -14,7 +14,7 @@ BEGIN {
 
 # Pithub::GitData::Blobs->create
 {
-    my $json = JSON::Any->new;
+    my $json = JSON->new;
     my $obj = Pithub::Test->create( 'Pithub::GitData::Blobs', user => 'foo', repo => 'bar' );
 
     isa_ok $obj, 'Pithub::GitData::Blobs';
@@ -69,7 +69,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json = JSON::Any->new;
+        my $json = JSON->new;
         my $result = $obj->create( data => { message => 'my commit message' } );
         is $result->request->method, 'POST', 'HTTP method';
         is $result->request->uri->path, '/repos/foo/bar/git/commits', 'HTTP path';
@@ -125,7 +125,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json = JSON::Any->new;
+        my $json = JSON->new;
         my $result = $obj->create( data => { ref => 'refs/heads/master' } );
         is $result->request->method, 'POST', 'HTTP method';
         is $result->request->uri->path, '/repos/foo/bar/git/refs', 'HTTP path';
@@ -171,7 +171,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json = JSON::Any->new;
+        my $json = JSON->new;
         my $result = $obj->update( ref => 'foo/bar', data => { sha => '123' } );
         is $result->request->method, 'PATCH', 'HTTP method';
         is $result->request->uri->path, '/repos/foo/bar/git/refs/foo/bar', 'HTTP path';
@@ -210,7 +210,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json   = JSON::Any->new;
+        my $json   = JSON->new;
         my $result = $obj->create(
             data => {
                 message => 'Tagged v0.1',
@@ -267,7 +267,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json = JSON::Any->new;
+        my $json = JSON->new;
         my $result = $obj->create( data => { tree => [ { path => 'file1.pl' } ] } );
         is $result->request->method, 'POST', 'HTTP method';
         is $result->request->uri->path, '/repos/foo/bar/git/trees', 'HTTP path';

--- a/t/issues.t
+++ b/t/issues.t
@@ -1,6 +1,6 @@
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use JSON::Any;
+use JSON;
 use Pithub::Test;
 use Test::Most;
 
@@ -26,7 +26,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json   = JSON::Any->new;
+        my $json   = JSON->new;
         my $result = $obj->create(
             data => {
                 assignee  => 'octocat',
@@ -108,7 +108,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json   = JSON::Any->new;
+        my $json   = JSON->new;
         my $result = $obj->update(
             issue_id => 123,
             data     => {
@@ -183,7 +183,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json   = JSON::Any->new;
+        my $json   = JSON->new;
         my $result = $obj->create(
             issue_id => 123,
             data     => { body => 'comment' }
@@ -263,7 +263,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json   = JSON::Any->new;
+        my $json   = JSON->new;
         my $result = $obj->update(
             comment_id => 123,
             data       => { body => 'comment' }
@@ -331,7 +331,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json   = JSON::Any->new;
+        my $json   = JSON->new;
         my $result = $obj->add(
             issue_id => 123,
             data     => [qw(label1 label2)],
@@ -356,7 +356,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json   = JSON::Any->new;
+        my $json   = JSON->new;
         my $result = $obj->create(
             data => {
                 name  => 'label1',
@@ -484,7 +484,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json   = JSON::Any->new;
+        my $json   = JSON->new;
         my $result = $obj->replace(
             issue_id => 123,
             data     => [qw(label1 label2)],
@@ -509,7 +509,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json   = JSON::Any->new;
+        my $json   = JSON->new;
         my $result = $obj->update(
             label => 123,
             data  => {
@@ -537,7 +537,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json   = JSON::Any->new;
+        my $json   = JSON->new;
         my $result = $obj->create(
             data => {
                 description => 'String',
@@ -621,7 +621,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json   = JSON::Any->new;
+        my $json   = JSON->new;
         my $result = $obj->update(
             milestone_id => 123,
             data         => {

--- a/t/orgs.t
+++ b/t/orgs.t
@@ -1,6 +1,6 @@
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use JSON::Any;
+use JSON;
 use Pithub::Test;
 use Test::Most;
 use MIME::Base64 qw();
@@ -89,7 +89,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json   = JSON::Any->new;
+        my $json   = JSON->new;
         my $result = $obj->update(
             org  => 'some-org',
             data => {
@@ -310,7 +310,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json   = JSON::Any->new;
+        my $json   = JSON->new;
         my $result = $obj->create(
             org  => 'blorg',
             data => {
@@ -524,7 +524,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json   = JSON::Any->new;
+        my $json   = JSON->new;
         my $result = $obj->update(
             team_id => 123,
             data    => {

--- a/t/pull_requests.t
+++ b/t/pull_requests.t
@@ -1,6 +1,6 @@
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use JSON::Any;
+use JSON;
 use Pithub::Test;
 use Test::Most;
 
@@ -38,7 +38,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json   = JSON::Any->new;
+        my $json   = JSON->new;
         my $result = $obj->create(
             data => {
                 base  => 'master',
@@ -139,7 +139,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json   = JSON::Any->new;
+        my $json   = JSON->new;
         my $result = $obj->update(
             pull_request_id => 123,
             data            => {
@@ -174,7 +174,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json = JSON::Any->new;
+        my $json = JSON->new;
         my $result = $obj->create( pull_request_id => 123, data => { body => 'some comment' } );
         is $result->request->method, 'POST', 'HTTP method';
         is $result->request->uri->path, '/repos/foo/bar/pulls/123/comments', 'HTTP path';
@@ -254,7 +254,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json = JSON::Any->new;
+        my $json = JSON->new;
         my $result = $obj->update( comment_id => 123, data => { body => 'some comment' } );
         is $result->request->method, 'PATCH', 'HTTP method';
         is $result->request->uri->path, '/repos/foo/bar/pulls/comments/123', 'HTTP path';

--- a/t/repos.t
+++ b/t/repos.t
@@ -1,6 +1,6 @@
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use JSON::Any;
+use JSON;
 use Pithub::Test;
 use Test::Most;
 
@@ -29,7 +29,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json = JSON::Any->new;
+        my $json = JSON->new;
         my $result = $obj->create( data => { foo => 1 } );
         is $result->request->method, 'POST', 'HTTP method';
         is $result->request->uri->path, '/user/repos', 'HTTP path';
@@ -38,7 +38,7 @@ BEGIN {
     }
 
     {
-        my $json = JSON::Any->new;
+        my $json = JSON->new;
         my $result = $obj->create( org => 'foobarorg', data => { bar => 1 } );
         is $result->request->method, 'POST', 'HTTP method';
         is $result->request->uri->path, '/orgs/foobarorg/repos', 'HTTP path';
@@ -118,7 +118,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json = JSON::Any->new;
+        my $json = JSON->new;
         my $result = $obj->update( user => 'bla', repo => 'fasel', data => { foo => 1 } );
         is $result->request->method, 'PATCH', 'HTTP method';
         is $result->request->uri->path, '/repos/bla/fasel', 'HTTP path';
@@ -209,7 +209,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json = JSON::Any->new;
+        my $json = JSON->new;
         my $result = $obj->create_comment( sha => 123, data => { body => 'some comment' } );
         is $result->request->method, 'POST', 'HTTP method';
         is $result->request->uri->path, '/repos/foo/bar/commits/123/comments', 'HTTP path';
@@ -300,7 +300,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json = JSON::Any->new;
+        my $json = JSON->new;
         my $result = $obj->update_comment( comment_id => 123, data => { body => 'some comment' } );
         is $result->request->method, 'PATCH', 'HTTP method';
         is $result->request->uri->path, '/repos/foo/bar/comments/123', 'HTTP path';
@@ -474,7 +474,7 @@ BEGIN {
     }
 
     {
-        my $json = JSON::Any->new;
+        my $json = JSON->new;
         my $result = $obj->create( org => 'foobarorg' );
         is $result->request->method, 'POST', 'HTTP method';
         is $result->request->uri->path, '/repos/foo/bar/forks', 'HTTP path';
@@ -498,7 +498,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json = JSON::Any->new;
+        my $json = JSON->new;
         my $result = $obj->create( data => { title => 'some key' } );
         is $result->request->method, 'POST', 'HTTP method';
         is $result->request->uri->path, '/repos/foo/bar/keys', 'HTTP path';
@@ -563,7 +563,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json = JSON::Any->new;
+        my $json = JSON->new;
         my $result = $obj->update( key_id => 123, data => { title => 'some key' } );
         is $result->request->method, 'PATCH', 'HTTP method';
         is $result->request->uri->path, '/repos/foo/bar/keys/123', 'HTTP path';
@@ -823,7 +823,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json = JSON::Any->new;
+        my $json = JSON->new;
         my $result = $obj->create( data => { name => 'web' } );
         is $result->request->method, 'POST', 'HTTP method';
         is $result->request->uri->path, '/repos/foo/bar/hooks', 'HTTP path';
@@ -849,7 +849,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json = JSON::Any->new;
+        my $json = JSON->new;
         my $result = $obj->update( hook_id => 123, data => { name => 'irc' } );
         is $result->request->method, 'PATCH', 'HTTP method';
         is $result->request->uri->path, '/repos/foo/bar/hooks/123', 'HTTP path';

--- a/t/users.t
+++ b/t/users.t
@@ -1,6 +1,6 @@
 use FindBin;
 use lib "$FindBin::Bin/lib";
-use JSON::Any;
+use JSON;
 use Pithub::Test;
 use Test::Most;
 
@@ -81,7 +81,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json = JSON::Any->new;
+        my $json = JSON->new;
         my $result = $obj->add( data => ['foo@bar.com'] );
         is $result->request->method, 'POST', 'HTTP method';
         is $result->request->uri->path, '/user/emails', 'HTTP path';
@@ -90,7 +90,7 @@ BEGIN {
     }
 
     {
-        my $json = JSON::Any->new;
+        my $json = JSON->new;
         my $result = $obj->add( data => [ 'foo@bar.com', 'bar@foo.com' ] );
         is $result->request->method, 'POST', 'HTTP method';
         is $result->request->uri->path, '/user/emails', 'HTTP path';
@@ -111,7 +111,7 @@ BEGIN {
     ok $obj->token(123), 'Token set';
 
     {
-        my $json = JSON::Any->new;
+        my $json = JSON->new;
         my $result = $obj->delete( data => ['foo@bar.com'] );
         is $result->request->method, 'DELETE', 'HTTP method';
         is $result->request->uri->path, '/user/emails', 'HTTP path';
@@ -120,7 +120,7 @@ BEGIN {
     }
 
     {
-        my $json = JSON::Any->new;
+        my $json = JSON->new;
         my $result = $obj->delete( data => [ 'foo@bar.com', 'bar@foo.com' ] );
         is $result->request->method, 'DELETE', 'HTTP method';
         is $result->request->uri->path, '/user/emails', 'HTTP path';


### PR DESCRIPTION
Is there any reason why you are using `JSON::Any`? I've replaced it with `JSON` and it seems to work just as well, with the added benefit of having one dependency less.
