### PR TITLE
Try adding Coveralls.io support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ perl:
   - "5.10"
 env: PERL_CPANM_OPT="--notest --force --skip-satisfied"
 before_install:
-  - "cpanm Dist::Zilla"
-  - "cpanm Test::Pod"
+  - "cpanm Dist::Zilla Test::Pod Devel::Cover::Report::Coveralls Dist::Zilla::App::Command::cover"
   - "dzil authordeps | xargs cpanm"
 install: "dzil listdeps | xargs cpanm"
-script: "dzil test --release"
+script: "RELEASE_TESTING=1 dzil cover -report coveralls -outputdir $PWD/cover_db"


### PR DESCRIPTION
- Using "dzil cover" instead of "dzil test" because it supports running cover commands inside the build directory where the cover_db lives.  Could maybe do it with HARNESS_PERL_SWITCHES.
- Because "dzil cover" doesn't support test switches, RELEASE_TESTING=1 simulates "dzil test --release"
- Put all the cpanm installs into one line for efficiency.

It works.
