### PR TITLE
Add the ability to get info about a single branch.

### DIFF
--- a/lib/Pithub/Repos.pm
+++ b/lib/Pithub/Repos.pm
@@ -18,6 +18,39 @@ use Pithub::Repos::Statuses;
 use Pithub::Repos::Watching;
 extends 'Pithub::Base';
 
+=method branch
+
+Get information about a single branch.
+
+    GET /repos/:owner/:repo/branches/:branch
+
+Example:
+
+    my $result = Pithub->new->branch(
+        user => 'plu',
+        repo => 'Pithub',
+        branch => "master"
+    );
+
+See also L<branches> to get a list of all branches.
+
+=cut
+
+sub branch {
+    my ( $self, %args ) = @_;
+    croak 'Missing key in parameters: branch (string)' unless defined $args{branch};
+    $self->_validate_user_repo_args( \%args );
+    return $self->request(
+        method => 'GET',
+        path   => sprintf(
+            '/repos/%s/%s/branches/%s', delete $args{user},
+                                        delete $args{repo},
+                                        delete $args{branch},
+        ),
+        %args,
+    );
+}
+
 =method branches
 
 =over
@@ -32,6 +65,8 @@ Examples:
 
     my $repos  = Pithub::Repos->new;
     my $result = $repos->branches( user => 'plu', repo => 'Pithub' );
+
+See also L<branch> to get information about a single branch.
 
 =back
 

--- a/t/live/repos.t
+++ b/t/live/repos.t
@@ -38,6 +38,17 @@ SKIP: {
         is $result->content->{owner}{login}, 'plu', 'Pithub::Repos->get: Attribute owner.login';
     }
 
+    subtest "Pithub::Repos->branch" => sub {
+        my $result = $p->repos->branch(
+            user        => 'plu',
+            repo        => 'Pithub',
+            branch      => 'master'
+        );
+        ok $result->success;
+        is $result->content->{name}, 'master';
+        like $result->content->{commit}{sha}, qr{^[a-f0-9]+$};
+    };
+
     # Pithub::Repos->languages
     {
         my $result = $p->repos->languages( user => 'plu', repo => 'Pithub' );

--- a/t/repos.t
+++ b/t/repos.t
@@ -77,6 +77,29 @@ subtest "Pithub::Repos->delete" => sub {
     }
 }
 
+
+subtest "Pithub::Repos->branch" => sub {
+    my $obj = Pithub::Test::Factory->create(
+        'Pithub::Repos',
+        user => 'foo',
+        repo => 'bar'
+    );
+
+    isa_ok $obj, 'Pithub::Repos';
+
+    subtest "too few arguments" => sub {
+        throws_ok { $obj->branch } qr/^Missing key in parameters: branch/;
+    };
+
+    subtest "basic get branch" => sub {
+        my $result = $obj->branch( branch => "master" );
+        is $result->request->method, 'GET', 'HTTP method';
+        is $result->request->uri->path, '/repos/foo/bar/branches/master', 'HTTP path';
+        my $http_request = $result->request;
+        is $http_request->content, '', 'HTTP body';
+    };
+};
+
 # Pithub::Repos->list
 {
     my $obj = Pithub::Test::Factory->create('Pithub::Repos');


### PR DESCRIPTION
I thought about adding Pithub::Repos::Branches.  I decided against it.
- The API docs don't break it up that way.
- There's only two things you can do with branches, list them and get one.
- Pithub::Repos::Branches can always be added later and these be made into
  compatibility wrappers.

For #171
