### PR TITLE
Use Path::Tiny instead of File::Slurp and File::Basename.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -39,7 +39,7 @@ first_version = 0.01000
 [Git::Tag]
 
 [Prereqs / TestRequires]
-File::Slurp = 0
+Path::Tiny = 0.037
 Test::Most = 0
 MIME::Base64 = 0
 Import::Into = 1.002004

--- a/examples/gitdata_commit.pl
+++ b/examples/gitdata_commit.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
-use File::Slurp;
+use Path::Tiny;
 use Pithub::GitData;
 
 my $git = Pithub::GitData->new(
@@ -10,7 +10,7 @@ my $git = Pithub::GitData->new(
     user  => 'plu',
 );
 
-my $content = File::Slurp::read_file(__FILE__);
+my $content = path(__FILE__)->slurp;
 
 # the encoding can also be 'base64', if necessary
 my $blob = $git->blobs->create(

--- a/lib/Pithub/Repos/Contents.pm
+++ b/lib/Pithub/Repos/Contents.pm
@@ -25,6 +25,8 @@ C<< master >>.
 
 Examples:
 
+    use Path::Tiny;
+
     my $c = Pithub::Repos::Contents->new(
         repo => 'Pithub',
         user => 'plu'
@@ -32,12 +34,12 @@ Examples:
 
     my $result = $c->archive( archive_format => 'tarball' );
     if ( $result->success ) {
-        File::Slurp::write_file('Pithub-master.tgz', $result->raw_content);
+        path('Pithub-master.tgz')->spew($result->raw_content);
     }
 
     $result = $c->archive( archive_format => 'tarball', ref => 'other_branch' );
     if ( $result->success ) {
-        File::Slurp::write_file('Pithub-other_branch.tgz', $result->raw_content);
+        path('Pithub-other_branch.tgz')->spew($result->raw_content);
     }
 
 =back

--- a/t/lib/Pithub/Test/UA.pm
+++ b/t/lib/Pithub/Test/UA.pm
@@ -2,8 +2,7 @@ package    # hide from PAUSE
   Pithub::Test::UA;
 
 use Moo;
-use File::Basename qw(dirname);
-use File::Slurp qw(read_file);
+use Path::Tiny;
 use HTTP::Response;
 use Test::More;
 
@@ -11,8 +10,8 @@ my @responses;
 
 sub add_response {
     my ( $self, $path ) = @_;
-    my $full_path = sprintf '%s/http_response/api.github.com/%s', dirname(__FILE__), $path;
-    my $response_string = read_file($full_path);
+    my $full_path = sprintf '%s/http_response/api.github.com/%s', path(__FILE__)->dirname, $path;
+    my $response_string = path($full_path)->slurp;
     my $response = HTTP::Response->parse($response_string);
     push @responses, $response;
 }

--- a/t/live/repos.t
+++ b/t/live/repos.t
@@ -206,13 +206,11 @@ SKIP: {
     }
 
     {
-        require File::Basename;
-
         # Pithub::Repos::Downloads->create
         my $result = $p->repos->downloads->create(
             data => {
-                name         => File::Basename::basename(__FILE__),
-                size         => ( stat(__FILE__) )[7],
+                name         => path(__FILE__)->basename,
+                size         => -s __FILE__,
                 description  => 'This test (t/live.t)',
                 content_type => 'text/plain',
             },


### PR DESCRIPTION
File::Slurp has some sort of potential Unicode security problem, but
really this is an excuse to get rid of the salad of File modules in
favor of Path::Tiny.  Path::Tiny is the all in wonder file handling
module.

See https://rt.cpan.org/Ticket/Display.html?id=100030
