### PR TITLE
Add Add/Remove membership API

### DIFF
--- a/lib/Pithub/Base.pm
+++ b/lib/Pithub/Base.pm
@@ -474,6 +474,7 @@ my @TOKEN_REQUIRED_REGEXP = (
     qr{^PUT /repos/[^/]+/[^/]+/issues/[^/]+/labels$},
     qr{^PUT /repos/[^/]+/[^/]+/pulls/[^/]+/merge$},
     qr{^PUT /teams/[^/]+/members/.*$},
+    qr{^PUT /teams/[^/]+/memberships/.*$},
     qr{^PUT /teams/[^/]+/repos/.*$},
     qr{^PUT /user/following/.*$},
     qr{^PUT /user/starred/[^/]+/.*$},

--- a/lib/Pithub/Orgs/Teams.pm
+++ b/lib/Pithub/Orgs/Teams.pm
@@ -359,6 +359,11 @@ sub list_repos {
 
 =over
 
+The "Remove team member" API (described below) is deprecated and
+is scheduled for removal in the next major version of the API. We
+recommend using the Remove team membership API instead. It allows
+you to remove both active and pending memberships.
+
 In order to remove a user from a team, the authenticated user must
 have 'admin' permissions to the team or be an owner of the org that
 the team is associated with. NOTE: This does not delete the user,
@@ -385,6 +390,41 @@ sub remove_member {
     return $self->request(
         method => 'DELETE',
         path   => sprintf( '/teams/%s/members/%s', delete $args{team_id}, delete $args{user} ),
+        %args,
+    );
+}
+
+=method remove_membership
+
+=over
+
+In order to remove a membership between a user and a team,
+the authenticated user must have 'admin' permissions to
+the team or be an owner of the organization that the team
+is associated with. NOTE: This does not delete the user,
+it just removes their membership from the team.
+
+    DELETE /teams/:id/memberships/:user
+
+Examples:
+
+    my $t = Pithub::Orgs::Teams->new;
+    my $result = $t->remove_membership(
+        team_id => 1,
+        user    => 'plu',
+    );
+
+=back
+
+=cut
+
+sub remove_membership {
+    my ( $self, %args ) = @_;
+    croak 'Missing key in parameters: team_id' unless $args{team_id};
+    croak 'Missing key in parameters: user'    unless $args{user};
+    return $self->request(
+        method => 'DELETE',
+        path   => sprintf( '/teams/%s/memberships/%s', delete $args{team_id}, delete $args{user} ),
         %args,
     );
 }

--- a/lib/Pithub/Orgs/Teams.pm
+++ b/lib/Pithub/Orgs/Teams.pm
@@ -10,6 +10,11 @@ extends 'Pithub::Base';
 
 =over
 
+The "Add team member" API (described below) is deprecated and is
+scheduled for removal in the next major version of the API. We
+recommend using the Add team membership API instead. It allows
+you to invite new organization members to your teams.
+
 In order to add a user to a team, the authenticated user must have
 'admin' permissions to the team or be an owner of the org that the
 team is associated with.
@@ -35,6 +40,44 @@ sub add_member {
     return $self->request(
         method => 'PUT',
         path   => sprintf( '/teams/%s/members/%s', delete $args{team_id}, delete $args{user} ),
+        %args,
+    );
+}
+
+=method add_membership
+
+=over
+
+If the user is already a member of the team’s organization, this
+endpoint will add the user to the team. In order to add a membership
+between an organization member and a team, the authenticated user
+must be an organization owner or a maintainer of the team.
+
+    PUT /teams/:id/memberships/:user
+
+Examples:
+
+    my $t = Pithub::Orgs::Teams->new;
+    my $result = $t->add_membership(
+        team_id => 1,
+        user    => 'plu',
+        data    => {
+            role => 'member',
+        }
+    );
+
+=back
+
+=cut
+
+sub add_membership {
+    my ( $self, %args ) = @_;
+    croak 'Missing key in parameters: team_id' unless $args{team_id};
+    croak 'Missing key in parameters: user'    unless $args{user};
+    croak 'Missing key in parameters: data'    unless $args{data};
+    return $self->request(
+        method => 'PUT',
+        path   => sprintf( '/teams/%s/memberships/%s', delete $args{team_id}, delete $args{user} ),
         %args,
     );
 }

--- a/t/basic.t
+++ b/t/basic.t
@@ -105,7 +105,7 @@ my @tree = (
             {
                 accessor => 'teams',
                 isa      => 'Pithub::Orgs::Teams',
-                methods  => [qw(add_member add_repo create delete get has_repo is_member list list_members list_repos remove_member remove_repo update)],
+                methods  => [qw(add_member add_membership add_repo create delete get has_repo is_member list list_members list_repos remove_member remove_repo update)],
             },
         ],
     },

--- a/t/basic.t
+++ b/t/basic.t
@@ -105,7 +105,7 @@ my @tree = (
             {
                 accessor => 'teams',
                 isa      => 'Pithub::Orgs::Teams',
-                methods  => [qw(add_member add_membership add_repo create delete get has_repo is_member list list_members list_repos remove_member remove_repo update)],
+                methods  => [qw(add_member add_membership add_repo create delete get has_repo is_member list list_members list_repos remove_member remove_membership remove_repo update)],
             },
         ],
     },

--- a/t/orgs.t
+++ b/t/orgs.t
@@ -513,6 +513,27 @@ BEGIN {
     }
 }
 
+# Pithub::Orgs::Teams->remove_membership
+{
+    my $obj = Pithub::Test::Factory->create('Pithub::Orgs::Teams');
+
+    isa_ok $obj, 'Pithub::Orgs::Teams';
+
+    throws_ok { $obj->remove_membership } qr{Missing key in parameters: team_id}, 'No parameters';
+    throws_ok { $obj->remove_membership( team_id => 123 ) } qr{Missing key in parameters: user}, 'No user parameter';
+    throws_ok { $obj->remove_membership( team_id => 123, user => 'bar' ); } qr{Access token required for: DELETE /teams/123/memberships/bar\s+}, 'Token required';
+
+    ok $obj->token(123), 'Token set';
+
+    {
+        my $result = $obj->remove_membership( team_id => 123, user => 'bar' );
+        is $result->request->method, 'DELETE', 'HTTP method';
+        is $result->request->uri->path, '/teams/123/memberships/bar', 'HTTP path';
+        my $http_request = $result->request;
+        is $http_request->content, '', 'HTTP body';
+    }
+}
+
 # Pithub::Orgs::Teams->remove_repo
 {
     my $obj = Pithub::Test::Factory->create('Pithub::Orgs::Teams');

--- a/t/orgs.t
+++ b/t/orgs.t
@@ -276,6 +276,28 @@ BEGIN {
     }
 }
 
+# Pithub::Orgs::Teams->add_membership
+{
+    my $obj = Pithub::Test::Factory->create('Pithub::Orgs::Teams');
+
+    isa_ok $obj, 'Pithub::Orgs::Teams';
+
+    throws_ok { $obj->add_membership } qr{Missing key in parameters: team_id}, 'No parameters';
+    throws_ok { $obj->add_membership( team_id => 123 ) } qr{Missing key in parameters: user}, 'No user parameter';
+    throws_ok { $obj->add_membership( team_id => 123, user => 'bar' ) } qr{Missing key in parameters: data}, 'No user parameter';
+    throws_ok { $obj->add_membership( team_id => 123, user => 'bar', data => { role => 'member' } ); } qr{Access token required for: PUT /teams/123/memberships/bar\s+}, 'Token required';
+
+    ok $obj->token(123), 'Token set';
+
+    {
+        my $result = $obj->add_membership( team_id => 123, user => 'bar', data => { role => 'member' } );
+        is $result->request->method, 'PUT', 'HTTP method';
+        is $result->request->uri->path, '/teams/123/memberships/bar', 'HTTP path';
+        my $http_request = $result->request;
+        is $http_request->content, '{"role":"member"}', 'HTTP body';
+    }
+}
+
 # Pithub::Orgs::Teams->add_repo
 {
     my $obj = Pithub::Test::Factory->create('Pithub::Orgs::Teams');


### PR DESCRIPTION
Add/Remove team membership API are instead of Add/Remove team member API.
Add/Remove team member API are deprecated and scheduled for removal in the next major version of Github API.

- https://developer.github.com/v3/orgs/teams/#add-team-member
- https://developer.github.com/v3/orgs/teams/#remove-team-member