### PR TITLE
CPANTS fixes (PRC)

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -11,6 +11,7 @@ authority = cpan:PLU
 [CheckChangesHasContent]
 [MetaConfig]
 [MetaJSON]
+[MinimumPerl]
 [NextRelease]
 [PkgVersion]
 [PodSyntaxTests]
@@ -53,3 +54,4 @@ JSON::MaybeXS = 1.003003
 LWP::Protocol::https = 0
 LWP::UserAgent = 0
 Moo = 1.001000
+URI = 0


### PR DESCRIPTION
This fixes two remaining CPANTS issues. There is one issue remaining after this, about Test::Pod not being declared as a test requirement. But I imagine this is an issue with the PodSyntaxTests plugin rather than with Pithub itself.

This PR brought to you by the CPAN PRC! 
