### PR TITLE
Add wishlisted methods to Pithub::Repos.

### DIFF
--- a/lib/Pithub/Repos.pm
+++ b/lib/Pithub/Repos.pm
@@ -4,6 +4,7 @@ package Pithub::Repos;
 
 use Moo;
 use Carp qw(croak);
+use Pithub::Issues;
 use Pithub::Repos::Collaborators;
 use Pithub::Repos::Commits;
 use Pithub::Repos::Contents;
@@ -269,6 +270,16 @@ Provides access to L<Pithub::Repos::Hooks>.
 
 sub hooks {
     return shift->_create_instance('Pithub::Repos::Hooks', @_);
+}
+
+=method issues
+
+Provides access to L<Pithub::Issues> for this repo.
+
+=cut
+
+sub issues {
+    return shift->_create_instance('Pithub::Issues', @_);
 }
 
 =method keys

--- a/lib/Pithub/Repos.pm
+++ b/lib/Pithub/Repos.pm
@@ -5,6 +5,7 @@ package Pithub::Repos;
 use Moo;
 use Carp qw(croak);
 use Pithub::Issues;
+use Pithub::PullRequests;
 use Pithub::Repos::Collaborators;
 use Pithub::Repos::Commits;
 use Pithub::Repos::Contents;
@@ -385,6 +386,16 @@ sub list {
             %args,
         );
     }
+}
+
+=method pull_requests
+
+Provides access to L<Pithub::PullRequests>.
+
+=cut
+
+sub pull_requests {
+    return shift->_create_instance('Pithub::PullRequests', @_);
 }
 
 =method releases

--- a/t/basic.t
+++ b/t/basic.t
@@ -157,6 +157,11 @@ my @tree = (
                 methods  => [qw(create delete get list update test)],
             },
             {
+                accessor => 'issues',
+                isa      => 'Pithub::Issues',
+                methods  => [qw(create get list update)],
+            },
+            {
                 accessor => 'keys',
                 isa      => 'Pithub::Repos::Keys',
                 methods  => [qw(create delete get list)],

--- a/t/basic.t
+++ b/t/basic.t
@@ -167,6 +167,11 @@ my @tree = (
                 methods  => [qw(create delete get list)],
             },
             {
+                accessor => 'pull_requests',
+                isa      => 'Pithub::PullRequests',
+                methods  => [qw(commits create files get is_merged list merge update)],
+            },
+            {
                 accessor => 'releases',
                 isa      => 'Pithub::Repos::Releases',
                 methods  => [qw(list get create update delete)],


### PR DESCRIPTION
This patch adds two methods to `Pithub::Repos`: `->issues` and `->pull_requests`. These act as shortcuts to access a `Pithub::Issues` and `Pithub::PullRequests` inheriting the parameters from the parent repo.

This makes it easier to use Pithub in the way requested in #194 and #196.

This PR brought to you by the CPAN pull request challenge.
