### PR TITLE
Add a rate_limit method to base

### DIFF
--- a/lib/Pithub/Base.pm
+++ b/lib/Pithub/Base.pm
@@ -739,6 +739,16 @@ sub has_token {
     return 0;
 }
 
+=method rate_limit
+
+Query the rate limit for the current object and authentication method.
+
+=cut
+
+sub rate_limit {
+    return shift->request( method => 'GET', path => '/rate_limit' );
+}
+
 sub _build__json {
     my ($self) = @_;
     return JSON->new->utf8($self->utf8);

--- a/t/basic.t
+++ b/t/basic.t
@@ -281,6 +281,7 @@ sub validate_tree {
             my $val = $obj->$accessor(@{ $node->{args} || [] });
             isa_ok $val, $node->{isa};
             can_ok $val, @$methods if @{ $methods || [] };
+            can_ok $val, 'rate_limit';
 
             foreach my $attr ( keys %attributes ) {
                 is $obj->$attr, $attributes{$attr}, "Attribute ${attr} was curried to ${obj}";


### PR DESCRIPTION
This implements the changes discussed in #202 to make it possible for all Pithub objects to check the current rate limit for whatever authentication method they are using.
