### PR TITLE
Add support for the Github markdown API

### DIFF
--- a/lib/Pithub.pm
+++ b/lib/Pithub.pm
@@ -616,6 +616,16 @@ sub issues {
     return shift->_create_instance('Pithub::Issues', @_);
 }
 
+=method markdown
+
+Provides access to L<Pithub::Markdown>.
+
+=cut
+
+sub markdown {
+    return shift->_create_instance('Pithub::Markdown', @_);
+}
+
 =method orgs
 
 Provides access to L<Pithub::Orgs>.

--- a/lib/Pithub/Markdown.pm
+++ b/lib/Pithub/Markdown.pm
@@ -6,6 +6,8 @@ use Moo;
 use Carp qw(croak);
 extends 'Pithub::Base';
 
+has [qw( mode context )] => ( is => 'rw' );
+
 =method render
 
 Render an arbitrary Markdown document
@@ -30,6 +32,11 @@ Example:
 sub render {
     my ( $self, %args ) = @_;
     croak 'Missing key in parameters: data (hashref)' unless defined $args{data};
+
+    for (qw( context mode )) {
+        $args{data}{$_} = $self->$_ if !exists $args{data}{$_} and $self->$_;
+    }
+
     return $self->request(
         method => 'POST',
         path   => '/markdown',

--- a/lib/Pithub/Markdown.pm
+++ b/lib/Pithub/Markdown.pm
@@ -1,0 +1,40 @@
+package Pithub::Markdown;
+
+# ABSTRACT: Github v3 Markdown API
+
+use Moo;
+use Carp qw(croak);
+extends 'Pithub::Base';
+
+=method render
+
+Render an arbitrary Markdown document
+
+    POST /markdown
+
+Example:
+
+    my $response = Pithub::Markdown->render(
+        data => {
+            text => "Hello world github/linguist#1 **cool**, and #1!",
+            context => "github/gollum",
+            mode => "gfm",
+        },
+    );
+
+    # Note that response is NOT in JSON, so ->content will die
+    my $html = $response->raw_content;
+
+=cut
+
+sub render {
+    my ( $self, %args ) = @_;
+    croak 'Missing key in parameters: data (hashref)' unless defined $args{data};
+    return $self->request(
+        method => 'POST',
+        path   => '/markdown',
+        %args,
+    );
+}
+
+1;

--- a/lib/Pithub/Repos.pm
+++ b/lib/Pithub/Repos.pm
@@ -5,6 +5,7 @@ package Pithub::Repos;
 use Moo;
 use Carp qw(croak);
 use Pithub::Issues;
+use Pithub::Markdown;
 use Pithub::PullRequests;
 use Pithub::Repos::Collaborators;
 use Pithub::Repos::Commits;
@@ -386,6 +387,20 @@ sub list {
             %args,
         );
     }
+}
+
+=method markdown
+
+Provides access to L<Pithub::Markdown> setting the current repository as the
+default context. This also sets the mode to default to 'gfm'.
+
+=cut
+
+sub markdown {
+    my $self = shift;
+    return $self->_create_instance('Pithub::Markdown',
+        mode => 'gfm', context => sprintf( '%s/%s', $self->user, $self->repo ),
+        @_);
 }
 
 =method pull_requests

--- a/t/basic.t
+++ b/t/basic.t
@@ -93,6 +93,11 @@ my @tree = (
         ],
     },
     {
+        accessor => 'markdown',
+        isa      => 'Pithub::Markdown',
+        methods  => [qw(render)],
+    },
+    {
         accessor => 'orgs',
         isa      => 'Pithub::Orgs',
         methods  => [qw(get list update)],

--- a/t/basic.t
+++ b/t/basic.t
@@ -172,6 +172,11 @@ my @tree = (
                 methods  => [qw(create delete get list)],
             },
             {
+                accessor => 'markdown',
+                isa      => 'Pithub::Markdown',
+                methods  => [qw(render)],
+            },
+            {
                 accessor => 'pull_requests',
                 isa      => 'Pithub::PullRequests',
                 methods  => [qw(commits create files get is_merged list merge update)],

--- a/t/repos.t
+++ b/t/repos.t
@@ -151,6 +151,17 @@ subtest "Pithub::Repos->branch" => sub {
     }
 }
 
+# Pithub::Repos->markdown
+{
+    my $obj = Pithub::Test::Factory->create( 'Pithub::Repos', user => 'foo', repo => 'bar' );
+
+    {
+        my $md = $obj->markdown;
+        is $md->mode, 'gfm', 'Markdown sets default mode to gfm';
+        is $md->context, 'foo/bar', 'Markdown sets default context to repo';
+    }
+}
+
 # Pithub::Repos->update
 {
     my $obj = Pithub::Test::Factory->create( 'Pithub::Repos', user => 'foo', repo => 'bar' );


### PR DESCRIPTION
This adds a new Pithub::Markdown object with a single method, `render`, which makes it possible to turn markdown text into HTML. The Pithub::Markdown object can have a default mode and context set, so that project-specific references (like this one: #198) are converted correctly.

This also adds a shortcut to Pithub::Repos which automatically sets the mode to `gfm` and the context to that of the repository itself, which just makes sense.

This implements the changes discussed in #198.
