### PR TITLE
Add .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,9 @@
+Andreas Marienborg <andreas.marienborg@gmail.com>
+Andreas Marienborg <andreas.marienborg@gmail.com> <omega@palle.net>
+Johannes Plunien <plu@pqpq.de>
+Johannes Plunien <plu@pqpq.de> <johannes.plunien@metaquark.de>
+Johannes Plunien <plu@pqpq.de> <johannes.plunien@xing.com>
+José Joaquín Atria <jjatria@cpan.org> <jjatria@gmail.com>
+SUZUKI Masashi <m15.suzuki.masashi@gmail.com>
+Zoffix Znet <cpan@zoffix.com>
+Zoffix Znet <cpan@zoffix.com> <zoffixznet@users.noreply.github.com>


### PR DESCRIPTION
This distribution currently uses the OALDERS author plugin bundle, which uses the Git::Contributors plugin to list contributors in a format that is readable by eg. MetaCPAN.

This patch adds a mailmap to canonicalise this list and remove repeated and mislabeled entries.