### PR TITLE
Document mode and context attributes for Pithub::Markdown

### DIFF
--- a/lib/Pithub/Markdown.pm
+++ b/lib/Pithub/Markdown.pm
@@ -8,6 +8,30 @@ extends 'Pithub::Base';
 
 has [qw( mode context )] => ( is => 'rw' );
 
+=attr mode
+
+The rendering mode. Can be either:
+
+=over
+
+=item *
+
+C<markdown> to render a document in plain Markdown, just like README.md
+files are rendered.
+
+=item *
+
+C<gfm> to render a document in GitHub Flavored Markdown, which creates
+links for user mentions as well as references to SHA-1 hashes, issues,
+and pull requests.
+
+=back
+
+=attr context
+
+The repository context to use when creating references in C<gfm> mode.
+Omit this parameter when using C<markdown> mode.
+
 =method render
 
 Render an arbitrary Markdown document


### PR DESCRIPTION
Adds documentation for the `mode` and `context` attributes of Pithub::Markdown.

Should solve the issue raised in #205  