### PR TITLE
Enable dzil author tests for Perl 5.26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,18 @@
 sudo: false
 language: perl
-perl:
-  - "5.26"
-  - "5.24"
-  - "5.22"
-  - "5.20"
-  - "5.18"
-  - "5.16"
-  - "5.14"
-  - "5.12"
-  - "5.10"
+matrix:
+  include:
+  - perl: "5.26"
+    env: AUTHOR_TESTING=1
+  - perl: "5.24"
+    env: COVERAGE=1
+  - perl: "5.22"
+  - perl: "5.20"
+  - perl: "5.18"
+  - perl: "5.16"
+  - perl: "5.14"
+  - perl: "5.12"
+  - perl: "5.10"
 notifications:
   email:
     recipients:
@@ -33,4 +36,5 @@ after_success:
   - coverage-report
 env:
   global:
-    - COVERAGE=1
+    - AUTHOR_TESTING=0
+    - COVERAGE=0


### PR DESCRIPTION
and only run coverage tests on 5.24