### PR TITLE
fix error in example

### DIFF
--- a/lib/Pithub/Markdown.pm
+++ b/lib/Pithub/Markdown.pm
@@ -40,7 +40,9 @@ Render an arbitrary Markdown document
 
 Example:
 
-    my $response = Pithub::Markdown->render(
+    use Pithub::Markdown;
+
+    my $response = Pithub::Markdown->new->render(
         data => {
             text => "Hello world github/linguist#1 **cool**, and #1!",
             context => "github/gollum",


### PR DESCRIPTION
The example in this POD doesn't work for me:

```perl
my $response = Pithub::Markdown->render(
    data => {
        text => "Hello world github/linguist#1 **cool**, and #1!",
        context => "github/gollum",
        mode => "gfm",
    },
);
 
# Note that response is NOT in JSON, so ->content will die
my $html = $response->raw_content;
```

gives:

```
$ perl example.pl 
Can't locate object method "render" via package "Pithub::Markdown" (perhaps you forgot to load "Pithub::Markdown"?) at example.pl line 1.
```

without a `use Pithub::Markdown` and gives

```
$ perl example.pl 
Can't use string ("Pithub::Markdown") as a HASH ref while "strict refs" in use at (eval 38) line 23.
```

without the `->new`.