### PR TITLE
Branches has its own class, adding rename and merge methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 *.sw*
 /*.tar.gz
 .tidyall.d
+MYMETA.*

--- a/examples/list_branches.pl
+++ b/examples/list_branches.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Pithub::Repos::Branches;
+
+my $b = Pithub::Repos::Branches->new(
+    per_page        => 100,
+    auto_pagination => 1,
+);
+my $result = $b->list( user => 'plu', repo => 'Pithub' );
+
+unless ( $result->success ) {
+    printf "something is fishy: %s\n", $result->response->status_line;
+    exit 1;
+}
+
+while ( my $row = $result->next ) {
+    printf "%s\n", $row->{name};
+}
+

--- a/examples/merge_branch.pl
+++ b/examples/merge_branch.pl
@@ -1,0 +1,17 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Pithub::Repos::Branches;
+
+my $b = Pithub::Repos::Branches->new(
+    token           => "ghp_YoUrTokeN"
+);
+
+# Merge a branch
+my $result = $b->merge( user => 'plu', repo => 'Pithub', data => { base => 'master', head => 'branch-to-merge' } );
+
+unless ( $result->success ) {
+    printf "something is fishy: %s\n", $result->response->status_line;
+    exit 1;
+}

--- a/examples/rename_branch.pl
+++ b/examples/rename_branch.pl
@@ -1,0 +1,18 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Pithub::Repos::Branches;
+
+my $b = Pithub::Repos::Branches->new(
+    token           => "ghp_YoUrTokeN"
+);
+
+# Rename branch
+my $result = $b->rename( user => 'plu', repo => 'Pithub', data => { branch => 'oldname', new_name => 'newname' } );
+
+unless ( $result->success ) {
+    printf "something is fishy: %s\n", $result->response->status_line;
+    exit 1;
+}
+

--- a/lib/Pithub/Repos.pm
+++ b/lib/Pithub/Repos.pm
@@ -9,6 +9,7 @@ use Pithub::Markdown;
 use Pithub::PullRequests;
 use Pithub::Repos::Collaborators;
 use Pithub::Repos::Commits;
+use Pithub::Repos::Branches;
 use Pithub::Repos::Contents;
 use Pithub::Repos::Downloads;
 use Pithub::Repos::Forks;
@@ -21,68 +22,14 @@ use Pithub::Repos::Statuses;
 use Pithub::Repos::Watching;
 extends 'Pithub::Base';
 
-=method branch
-
-Get information about a single branch.
-
-    GET /repos/:owner/:repo/branches/:branch
-
-Example:
-
-    my $result = Pithub->new->branch(
-        user => 'plu',
-        repo => 'Pithub',
-        branch => "master"
-    );
-
-See also L<branches> to get a list of all branches.
-
-=cut
-
-sub branch {
-    my ( $self, %args ) = @_;
-    croak 'Missing key in parameters: branch (string)' unless defined $args{branch};
-    $self->_validate_user_repo_args( \%args );
-    return $self->request(
-        method => 'GET',
-        path   => sprintf(
-            '/repos/%s/%s/branches/%s', delete $args{user},
-                                        delete $args{repo},
-                                        delete $args{branch},
-        ),
-        %args,
-    );
-}
-
 =method branches
 
-=over
-
-=item *
-
-List Branches
-
-    GET /repos/:user/:repo/branches
-
-Examples:
-
-    my $repos  = Pithub::Repos->new;
-    my $result = $repos->branches( user => 'plu', repo => 'Pithub' );
-
-See also L<branch> to get information about a single branch.
-
-=back
+Provides access to L<Pithub::Repos::Branches>.
 
 =cut
 
 sub branches {
-    my ( $self, %args ) = @_;
-    $self->_validate_user_repo_args( \%args );
-    return $self->request(
-        method => 'GET',
-        path   => sprintf( '/repos/%s/%s/branches', delete $args{user}, delete $args{repo} ),
-        %args,
-    );
+    return shift->_create_instance('Pithub::Repos::Branches', @_);
 }
 
 =method collaborators

--- a/lib/Pithub/Repos/Branches.pm
+++ b/lib/Pithub/Repos/Branches.pm
@@ -1,0 +1,158 @@
+package Pithub::Repos::Branches;
+our $VERSION = '0.01037';
+# ABSTRACT: Github v3 Repo Commits API
+
+use Moo;
+use Carp qw( croak );
+extends 'Pithub::Base';
+
+=method get
+
+=over
+
+=item *
+
+Get a single branch
+
+    GET /repos/:user/:repo/branches/:branch
+
+Examples:
+
+    my $b = Pithub::Repos::Branches->new;
+    my $result = $b->get(
+        user => 'plu',
+        repo => 'Pithub',
+        branch  => 'master',
+    );
+
+See also L<branches> to get a list of all branches.
+
+=back
+
+=cut
+
+sub get {
+    my ( $self, %args ) = @_;
+    croak 'Missing key in parameters: branch' unless $args{branch};
+    $self->_validate_user_repo_args( \%args );
+    return $self->request(
+        method => 'GET',
+        path   => sprintf( '/repos/%s/%s/branches/%s', delete $args{user}, delete $args{repo}, delete $args{branch} ),
+        %args,
+    );
+}
+
+=method list
+
+=over
+
+=item *
+
+List branches on a repository
+
+    GET /repos/:user/:repo/branches
+
+Examples:
+
+    my $b = Pithub::Repos::Branches->new;
+    my $result = $b->list(
+        user => 'plu',
+        repo => 'Pithub',
+    );
+
+See also L<branch> to get information about a single branch.
+
+=back
+
+=cut
+
+sub list {
+    my ( $self, %args ) = @_;
+    $self->_validate_user_repo_args( \%args );
+    return $self->request(
+        method => 'GET',
+        path   => sprintf( '/repos/%s/%s/branches', delete $args{user}, delete $args{repo} ),
+        %args,
+    );
+}
+
+=method rename
+
+=over
+
+=item *
+
+Rename a branch
+
+    POST /repos/:user/:repo/branches/:branch/rename
+
+Examples:
+
+    my $b = Pithub::Repos::Branches->new;
+    my $result = $b->rename(
+        user => 'plu',
+        repo => 'Pithub',
+        branch  => 'travis',
+	new_name => 'travis-ci'
+    );
+
+See also L<branches> to get a list of all branches.
+
+=back
+
+=cut
+
+sub rename {
+    my ( $self, %args ) = @_;
+    croak 'Missing parameters: data' unless $args{data};
+    croak 'Missing key in parameters: branch' unless $args{data}->{branch};
+    croak 'Missing key in parameters: new_name' unless $args{data}->{new_name};
+    $self->_validate_user_repo_args( \%args );
+    return $self->request(
+        method => 'POST',
+        path   => sprintf( '/repos/%s/%s/branches/%s/rename', delete $args{user}, delete $args{repo}, $args{data}->{branch} ),
+        %args,
+    );
+}
+
+=method merge
+
+=over
+
+=item *
+
+Merge a branch
+
+    POST /repos/:user/:repo/merges
+
+Examples:
+
+    my $b = Pithub::Repos::Branches->new;
+    my $result = $b->rename(
+        user => 'plu',
+        repo => 'Pithub',
+        base  => 'master',
+	head => 'travis',
+        message => 'My commit message'
+    );
+
+See also L<branches> to get a list of all branches.
+
+=back
+
+=cut
+
+sub merge {
+    my ( $self, %args ) = @_;
+    croak 'Missing parameters: data' unless $args{data};
+    croak 'Missing key in parameters: base' unless $args{data}->{base};
+    croak 'Missing key in parameters: head' unless $args{data}->{head};
+    $self->_validate_user_repo_args( \%args );
+    return $self->request(
+        method => 'POST',
+        path   => sprintf( '/repos/%s/%s/merges', delete $args{user}, delete $args{repo} ),
+        %args,
+    );
+}
+
+1;

--- a/t/basic.t
+++ b/t/basic.t
@@ -135,13 +135,19 @@ my @tree = (
     {
         accessor => 'repos',
         isa      => 'Pithub::Repos',
-        methods  => [qw(branches contributors create get languages list tags teams update)],
+        methods  => [qw(contributors create get languages list tags teams update)],
         subtree  => [
             {
                 accessor => 'collaborators',
                 isa      => 'Pithub::Repos::Collaborators',
                 methods  => [qw(add is_collaborator list remove)],
             },
+            {
+                accessor => 'branches',
+                isa      => 'Pithub::Repos::Branches',
+                methods  => [qw(get list rename merge)],
+            },
+
             {
                 accessor => 'commits',
                 isa      => 'Pithub::Repos::Commits',
@@ -319,7 +325,7 @@ sub validate_tree {
                 next if $node->{isa} eq 'Pithub::Repos::Downloads' and $method eq 'upload';
 
                 my $result;
-                my $data = {state => 'pending'};
+                my $data = {state => 'pending', branch => 'master', base => 'master', head => 'another_branch', new_name => 'new_name'};
 
                 # unfortunately the API expects arrayrefs on a very few calls
                 $data = []
@@ -331,6 +337,8 @@ sub validate_tree {
                         archive_format => 'tarball',
                         asset_id       => 1,
                         assignee       => 'john',
+                        base           => 'master',
+                        branch         => 'master',
                         collaborator   => 1,
                         comment_id     => 1,
                         content_type   => 'text/plain',
@@ -339,14 +347,15 @@ sub validate_tree {
                         email          => 'foo',
                         event_id       => 1,
                         gist_id        => 1,
+                        head           => 'branch',
                         hook_id        => 1,
                         issue_id       => 1,
                         key_id         => 1,
                         keyword        => 'foo',
-                        q              => 'foo',
                         label          => 1,
                         milestone_id   => 1,
                         name           => 'foo',
+                        new_name       => 'new',
                         options        => {
                             prepare_request => sub {
                                 shift->header( 'Accept' => 'foo.bar' );
@@ -354,6 +363,7 @@ sub validate_tree {
                         },
                         org             => 1,
                         pull_request_id => 1,
+                        q              => 'foo',
                         ref             => 1,
                         release_id      => 1,
                         repo            => 1,

--- a/t/multi.t
+++ b/t/multi.t
@@ -23,6 +23,7 @@ BEGIN {
     use_ok('Pithub::Repos');
     use_ok('Pithub::Repos::Collaborators');
     use_ok('Pithub::Repos::Commits');
+    use_ok('Pithub::Repos::Branches');
     use_ok('Pithub::Repos::Downloads');
     use_ok('Pithub::Repos::Forks');
     use_ok('Pithub::Repos::Keys');
@@ -287,16 +288,7 @@ test(
 test(
     code => sub {
         my ( $c_args, $m_args ) = @_;
-        return Pithub::Test::Factory->create( 'Pithub', %$c_args )->repos->branches(%$m_args);
-    },
-    path  => '/repos/plu/Pithub/branches',
-    tests => \@tests,
-);
-
-test(
-    code => sub {
-        my ( $c_args, $m_args ) = @_;
-        return Pithub::Test::Factory->create( 'Pithub::Repos', %$c_args )->branches(%$m_args);
+        return Pithub::Test::Factory->create( 'Pithub::Repos::Branches', %$c_args )->list(%$m_args);
     },
     path  => '/repos/plu/Pithub/branches',
     tests => \@tests,

--- a/t/repos.t
+++ b/t/repos.t
@@ -13,6 +13,7 @@ BEGIN {
     use_ok('Pithub::Repos');
     use_ok('Pithub::Repos::Collaborators');
     use_ok('Pithub::Repos::Commits');
+    use_ok('Pithub::Repos::Branches');
     use_ok('Pithub::Repos::Downloads');
     use_ok('Pithub::Repos::Forks');
     use_ok('Pithub::Repos::Hooks');
@@ -87,28 +88,59 @@ subtest "Pithub::Repos->delete" => sub {
     }
 }
 
+# Pithub::Repos::Branches->get
+{
+    my $obj = Pithub::Test::Factory->create( 'Pithub::Repos::Branches', user => 'foo', repo => 'bar' );
 
-subtest "Pithub::Repos->branch" => sub {
-    my $obj = Pithub::Test::Factory->create(
-        'Pithub::Repos',
-        user => 'foo',
-        repo => 'bar'
-    );
+    isa_ok $obj, 'Pithub::Repos::Branches';
 
-    isa_ok $obj, 'Pithub::Repos';
+    throws_ok { $obj->get } qr{Missing key in parameters: branch}, 'No parameters';
 
-    subtest "too few arguments" => sub {
-        throws_ok { $obj->branch } qr/^Missing key in parameters: branch/;
-    };
-
-    subtest "basic get branch" => sub {
-        my $result = $obj->branch( branch => "master" );
+    {
+        my $result = $obj->get( branch => 'mybranch' );
         is $result->request->method, 'GET', 'HTTP method';
-        is $result->request->uri->path, '/repos/foo/bar/branches/master', 'HTTP path';
-        my $http_request = $result->request;
-        is $http_request->content, '', 'HTTP body';
-    };
-};
+        is $result->request->uri->path, '/repos/foo/bar/branches/mybranch', 'HTTP path';
+    }
+}
+
+# Pithub::Repos::Branches->list
+{
+    my $obj = Pithub::Test::Factory->create( 'Pithub::Repos::Branches', user => 'foo', repo => 'bar' );
+
+    isa_ok $obj, 'Pithub::Repos::Branches';
+
+    {
+        my $result = $obj->list;
+        is $result->request->method, 'GET', 'HTTP method';
+        is $result->request->uri->path, '/repos/foo/bar/branches', 'HTTP path';
+    }
+}
+
+# Pithub::Repos::Branches->rename
+{
+    my $obj = Pithub::Test::Factory->create( 'Pithub::Repos::Branches', user => 'foo', repo => 'bar' );
+
+    isa_ok $obj, 'Pithub::Repos::Branches';
+
+    {
+        my $result = $obj->rename( data => { branch => 'old', new_name => 'new' } );
+        is $result->request->method, 'POST', 'HTTP method';
+        is $result->request->uri->path, '/repos/foo/bar/branches/old/rename', 'HTTP path';
+    }
+}
+
+# Pithub::Repos::Branches->merge
+{
+    my $obj = Pithub::Test::Factory->create( 'Pithub::Repos::Branches', user => 'foo', repo => 'bar' );
+
+    isa_ok $obj, 'Pithub::Repos::Branches';
+
+    {
+        my $result = $obj->merge(data => { base => 'base', head => 'head' } );
+        is $result->request->method, 'POST', 'HTTP method';
+        is $result->request->uri->path, '/repos/foo/bar/merges', 'HTTP path';
+    }
+}
 
 # Pithub::Repos->list
 {


### PR DESCRIPTION
Hello 😃 

I propose to add these methods `rename` and `merge` and doing this change required to reorganize the code to add a new `Pithub::Repos::Branches` (the same way is `Pithub::Repos::Commits` and friends).

