### PR TITLE
Fix that `per_page` parameter is sent if a query_form is set

### DIFF
--- a/lib/Pithub/Base.pm
+++ b/lib/Pithub/Base.pm
@@ -674,7 +674,8 @@ sub request {
     }
 
     if ( my $query = delete $args{query} ) {
-        $uri->query_form(%$query);
+        my %orig_query = $uri->query_form;
+        $uri->query_form(%orig_query, %$query);
     }
 
     my $request = $self->_request_for( $method, $uri, $data );

--- a/lib/Pithub/SearchV3.pm
+++ b/lib/Pithub/SearchV3.pm
@@ -121,6 +121,7 @@ sub _search {
             q => delete $args{q},
             ( exists $args{sort}  ? ( sort  => delete $args{sort} )  : () ),
             ( exists $args{order} ? ( order => delete $args{order} ) : () ),
+            ( exists $args{per_page} ? ( per_page => delete $args{per_page} ) : () ),
         },
         %args,
     );


### PR DESCRIPTION
`per_page` was never sent for a request when a `query_form` was given, as it was overwritten after initialization.

Also, SearchV3 did not respect a per_page during the search.

Both are fixed, but I am unsure if any tests need to be updated (sorry, I just needed a quick fix).