### PR TITLE
Allow fetching additional pages of pull requests

### DIFF
--- a/lib/Pithub/PullRequests.pm
+++ b/lib/Pithub/PullRequests.pm
@@ -253,6 +253,10 @@ sub list {
         path   => sprintf(
             '/repos/%s/%s/pulls', delete $args{user}, delete $args{repo}
         ),
+        params => {
+            per_page => 100,
+            page     => delete $args{page},
+        },
         %args,
     );
 }

--- a/lib/Pithub/PullRequests.pm
+++ b/lib/Pithub/PullRequests.pm
@@ -238,7 +238,9 @@ Examples:
     my $p = Pithub::PullRequests->new;
     my $result = $p->list(
         user => 'plu',
-        repo => 'Pithub'
+        repo => 'Pithub',
+        page => 2,
+            # Defaults to page 1, and defaults to a limit of 100 results
     );
 
 =back


### PR DESCRIPTION
Adds the ability to fetch additional pages, since the API limits you to 100 results at a time.