### PR TITLE
Allow fetching closed PRs as well.

### DIFF
--- a/lib/Pithub/PullRequests.pm
+++ b/lib/Pithub/PullRequests.pm
@@ -240,7 +240,10 @@ Examples:
         user => 'plu',
         repo => 'Pithub',
         page => 2,
-            # Defaults to page 1, and defaults to a limit of 100 results
+            # Defaults to page 1. Note that the GitHub API returns (a
+            # maximum of) 100 results per page.
+        state => 'open',
+            # Defaults to 'open', other options are 'closed' and 'all'
     );
 
 =back
@@ -250,6 +253,9 @@ Examples:
 sub list {
     my ( $self, %args ) = @_;
     $self->_validate_user_repo_args( \%args );
+
+    $args{state} ||= 'open';
+
     return $self->request(
         method => 'GET',
         path   => sprintf(
@@ -258,7 +264,8 @@ sub list {
         params => {
             per_page => 100,
             page     => delete $args{page},
-        },
+            state    => delete $args{state},
+          },
         %args,
     );
 }


### PR DESCRIPTION
Hey, friends, me again.

The GitHub API defaults to returning open PRs, but permits passing a 'state' argument of 'open', 'closed', or 'all'. This change allows passing that argument.

A warning is in order: while *most* GitHub repos have a fairly small number of open PRs, they can have thousands or tens of thousands of closed ones, and if you try to fetch all of them (ie, by incrementing the page argument) you will get rate limited pretty quickly. So ... either don't do that, or rate limit yourself.

So, this PR adds an (optional) state argument, defaulting to 'open' if you don't specify, so that existing behavior is unchanged. It also contains a doc clarification that setting `per_page` to 100 wasn't arbitrary, but that that's the default for that argument. The Github API *requires* that you pass a per_page argument when pass a page argument, and 100 is the max value permitted for that argument, so I just set it to that. Presumably that *could* change in the future.